### PR TITLE
Default button for landing page

### DIFF
--- a/src/app/components/ui/about-image.jsx
+++ b/src/app/components/ui/about-image.jsx
@@ -2,6 +2,7 @@
 
 import React from "react";
 import Image from "next/image";
+import DefaultButton from "./default-button";
 import { SiHtml5 } from "react-icons/si";
 import { SiCss3 } from "react-icons/si";
 import { SiTailwindcss } from "react-icons/si";
@@ -73,13 +74,14 @@ const AboutImage = () => {
             </div>
           </div>
           <div className="sm:mt-7 mt-2 justify-center flex">
-            <a
+            {/* <a
               href="/CV_Marcoff.pdf"
               download="CV_Marcoff.pdf"
               className="font-bold hover:text-blue-900 text-sm sm:text-2xl bg-blue-900 hover:bg-gray-800 hover:text-blue-900 text-white py-2 px-4 rounded inline-block"
             >
               Download CV
-            </a>
+            </a> */}
+            <DefaultButton text={"Download CV"} url={"/CV_Marcoff.pdf"} />
           </div>
         </div>
       </div>

--- a/src/app/components/ui/contact-form.jsx
+++ b/src/app/components/ui/contact-form.jsx
@@ -78,11 +78,6 @@ export default function ContactForm() {
           </fieldset>
         </div>
         <div className="flex justify-center">
-          {/* <input
-            type="submit"
-            value="Submit"
-            className="text-white bg-blue-900  px-6 py-1 rounded-xl cursor-pointer text-sm sm:text-lg  mt-3 mb-1"
-          /> */}
           <DefaultButton text={"Submit"} />
         </div>
       </form>

--- a/src/app/components/ui/contact-form.jsx
+++ b/src/app/components/ui/contact-form.jsx
@@ -2,6 +2,7 @@
 
 import React from "react";
 import { useForm } from "@formspree/react";
+import DefaultButton from "./default-button";
 
 export default function ContactForm() {
   const [state] = useForm("mleqbzyv");
@@ -77,11 +78,12 @@ export default function ContactForm() {
           </fieldset>
         </div>
         <div className="flex justify-center">
-          <input
+          {/* <input
             type="submit"
             value="Submit"
             className="text-white bg-blue-900  px-6 py-1 rounded-xl cursor-pointer text-sm sm:text-lg  mt-3 mb-1"
-          />
+          /> */}
+          <DefaultButton text={"Submit"} />
         </div>
       </form>
     </div>

--- a/src/app/components/ui/default-button.jsx
+++ b/src/app/components/ui/default-button.jsx
@@ -1,0 +1,12 @@
+import React from "react";
+
+export default function DefaultButton({ text }) {
+  return (
+    <div>
+      {" "}
+      <button className="text-white bg-blue-900  px-6 py-1 rounded-xl cursor-pointer text-sm sm:text-lg  mt-3 mb-1">
+        {text}
+      </button>
+    </div>
+  );
+}

--- a/src/app/components/ui/default-button.jsx
+++ b/src/app/components/ui/default-button.jsx
@@ -1,12 +1,22 @@
-import React from "react";
-
-export default function DefaultButton({ text }) {
-  return (
-    <div>
-      {" "}
-      <button className="text-white bg-blue-900  px-6 py-1 rounded-xl cursor-pointer text-sm sm:text-lg  mt-3 mb-1">
+export default function DefaultButton({ text, url }) {
+  if (url) {
+    return (
+      <a
+        className="text-white bg-blue-900 text-sm sm:text-lg px-6 py-1 rounded-xl mt-3 sm:mb-1 mb-5"
+        href={url}
+        target="_blank"
+        rel="noopener noreferrer"
+      >
         {text}
-      </button>
-    </div>
-  );
+      </a>
+    );
+  } else {
+    return (
+      <div>
+        <button className="text-white bg-blue-900 px-6 py-1 rounded-xl cursor-pointer text-sm sm:text-lg mt-3 mb-1">
+          {text}
+        </button>
+      </div>
+    );
+  }
 }

--- a/src/app/components/ui/default-button.jsx
+++ b/src/app/components/ui/default-button.jsx
@@ -1,8 +1,11 @@
 export default function DefaultButton({ text, url }) {
+  const buttonStyle =
+    "font-bold text-white bg-blue-900 hover:bg-gray-500 hover:text-blue-900 px-6 py-1 rounded-xl cursor-pointer text-sm sm:text-lg mt-3 mb-1";
+
   if (url) {
     return (
       <a
-        className="text-white bg-blue-900 text-sm sm:text-lg px-6 py-1 rounded-xl mt-3 sm:mb-1 mb-5"
+        className={buttonStyle}
         href={url}
         target="_blank"
         rel="noopener noreferrer"
@@ -13,9 +16,7 @@ export default function DefaultButton({ text, url }) {
   } else {
     return (
       <div>
-        <button className="text-white bg-blue-900 px-6 py-1 rounded-xl cursor-pointer text-sm sm:text-lg mt-3 mb-1">
-          {text}
-        </button>
+        <button className={buttonStyle}>{text}</button>
       </div>
     );
   }

--- a/src/app/components/ui/projects-carousel.jsx
+++ b/src/app/components/ui/projects-carousel.jsx
@@ -5,6 +5,7 @@ import Slider from "react-slick";
 import Image from "next/image";
 import "slick-carousel/slick/slick.css";
 import "slick-carousel/slick/slick-theme.css";
+import DefaultButton from "./default-button";
 
 const ProjectSlide = ({ imagePath, alt, title, description, url }) => (
   <div>
@@ -28,14 +29,15 @@ const ProjectSlide = ({ imagePath, alt, title, description, url }) => (
       </div>
     </div>
     <div className="flex justify-center items-center">
-      <a
+      {/* <a
         className="text-white bg-blue-900 text-sm sm:text-lg px-6 py-1 rounded-xl mt-3 sm:mb-1 mb-5"
         href={url}
         target="_blank"
         rel="noopener noreferrer"
       >
         Join the website
-      </a>
+      </a> */}
+      <DefaultButton text={"Join the website"} url={url} />
     </div>
   </div>
 );


### PR DESCRIPTION
n this pull request (PR), I created a default button that is reused in three components of the landing page: about, contact form, and projects. This way, cleaner code is generated without losing the specific functionality of each button.

In "About," the button continues to allow downloading the CV. In the projects carousel, it redirects the user to the indicated website. And in the form, it sends the contact email.